### PR TITLE
publish wheel using twine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,9 +177,11 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: pip install --user setuptools wheel
+          command: pip install --user setuptools wheel twine
 
       - run: python setup.py sdist bdist_wheel --universal
+
+      - run: twine upload dist/*
 
       - store_artifacts:
           path: dist


### PR DESCRIPTION
In this PR we use twine to publish both the sdist and bdist. The location and authentication have already been configured through environment variables in circle