### PR TITLE
[fix] Correctly encode infinite floats

### DIFF
--- a/conjure_python_client/_serde/encoder.py
+++ b/conjure_python_client/_serde/encoder.py
@@ -56,9 +56,10 @@ class ConjureEncoder(json.JSONEncoder):
 
     @classmethod
     def encode_primitive(cls, obj):
-        # TODO(forozco): support inifinities
-        if isinstance(obj, float) and (isnan(obj) or isinf(obj)):
+        if isinstance(obj, float) and isnan(obj):
             return 'NaN'
+        if isinstance(obj, float) and isinf(obj):
+            return '{}Infinity'.format('-' if obj < 0 else '')
         return obj
 
     @classmethod

--- a/scripts/download_conjure_python.sh
+++ b/scripts/download_conjure_python.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-VERSION=3.3.0
+VERSION=3.4.0
 ARTIFACT_NAME="conjure-python-${VERSION}"
 DOWNLOAD_OUTPUT="build/downloads/conjure-python.tgz"
 

--- a/scripts/download_test_server.sh
+++ b/scripts/download_test_server.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-VERSION=0.5.0
+VERSION=0.7.0
 TEST_CASES="test-cases"
 API="verification-api"
 SERVER="verification-server"

--- a/test/serde/test_encode_primitives.py
+++ b/test/serde/test_encode_primitives.py
@@ -26,7 +26,11 @@ def test_nan_float_encodes():
     assert(encoded == 'NaN')
 
 
-def test_inf_float_encodes():
-    encoded = ConjureEncoder.encode_primitive(float('inf'))
-    assert(encoded == 'NaN')
+@pytest.mark.parametrize("value,expected_encoded", [
+    (float('inf'), 'Infinity'),
+    (-float('inf'), '-Infinity'),
+])
+def test_inf_float_encodes(value, expected_encoded):
+    encoded = ConjureEncoder.encode_primitive(value)
+    assert(encoded == expected_encoded)
 


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
Infinite floats were encoded as `'NaN'`.

## After this PR
<!-- Describe at a high-level why this approach is better. -->

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
Infinite floats are encoded as `'Infinity'` or `'-Infinity'` to match https://github.com/palantir/conjure/blob/7b7dc9222de6a8d42107d5aabe5ab62aa8a1c6e0/docs/rfc/005-handling-double-nan-and-infinity.md.