### PR TITLE
[improvement] Include TraceID in the message for HTTPError

### DIFF
--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -81,12 +81,13 @@ class Service(object):
                     detail = e.response.json()
                 except ValueError:
                     detail = {'message': e.response.content}
+                detail['traceId'] = e.response.headers.get('X-B3-TraceId'),
             else:
                 detail = {}
             raise HTTPError(
                 'Error Name: {}. TraceId {}. Message: {}.'.format(
                     detail.get('errorName', 'UnknownError'),
-                    e.response.headers.get('X-B3-TraceId', 'No TraceId'),
+                    detail.get('traceId', 'No TraceId'),
                     detail.get('message', 'No Message')
                 ),
                 response=_response,


### PR DESCRIPTION
Python errors are, more than any others, printed out to interactive consoles rather than logged with context.
Including the traceid in the printout is going to help a bunch in debugging issues in interactive workflows.
