### PR TITLE
Update Conjure dependencies 

### DIFF
--- a/scripts/download_conjure_python.sh
+++ b/scripts/download_conjure_python.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-VERSION=3.4.0
+VERSION="$(grep "^com.palantir.conjure.python:conjure-python" < versions.props | tail -1 | sed 's/^com.palantir.conjure.python:conjure-python = \(.*\)$/\1/')"
 ARTIFACT_NAME="conjure-python-${VERSION}"
 DOWNLOAD_OUTPUT="build/downloads/conjure-python.tgz"
 

--- a/scripts/download_test_server.sh
+++ b/scripts/download_test_server.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-VERSION=0.12.1
+VERSION="$(grep "^com.palantir.conjure.verification:*" < versions.props | tail -1 | sed 's/^com.palantir.conjure.verification:\* = \(.*\)$/\1/')"
 TEST_CASES="verification-server-test-cases"
 API="verification-server-api"
 SERVER="verification-server"

--- a/versions.props
+++ b/versions.props
@@ -1,0 +1,2 @@
+com.palantir.conjure.python:conjure-python = 3.9.2
+com.palantir.conjure.verification:* = 0.15.0

--- a/versions.props
+++ b/versions.props
@@ -1,2 +1,2 @@
-com.palantir.conjure.python:conjure-python = 3.9.2
-com.palantir.conjure.verification:* = 0.15.0
+com.palantir.conjure.python:conjure-python = 3.4.0
+com.palantir.conjure.verification:* = 0.12.1


### PR DESCRIPTION
## Before this PR
Conjure dependency versions were hard coded into the download scripts

## After this PR
We defined the conjure dependencies in `versions.props` which will be automatically upgraded by excavator