### PR TITLE
[improvement] add support for hashing / settype + more tests

### DIFF
--- a/conjure_python_client/_lib/__init__.py
+++ b/conjure_python_client/_lib/__init__.py
@@ -27,4 +27,5 @@ __all__ = [
     'DictType',
     'ListType',
     'OptionalType',
+    'SetType'
 ]

--- a/conjure_python_client/_lib/types.py
+++ b/conjure_python_client/_lib/types.py
@@ -48,6 +48,7 @@ class SetType(ConjureType):
     def item_type(self):
         return self._item_type
 
+
 class DictType(ConjureType):
     key_type = None  # type: Type[DecodableType]
     value_type = None  # type: Type[DecodableType]

--- a/conjure_python_client/_lib/types.py
+++ b/conjure_python_client/_lib/types.py
@@ -24,7 +24,8 @@ class ConjureType(object):
 
 
 DecodableType = Union[
-    int, float, bool, str, ConjureType, List[Any], Dict[Any, Any], FrozenSet[Any]
+    int, float, bool, str, ConjureType,
+    List[Any], Dict[Any, Any], FrozenSet[Any]
 ]
 
 
@@ -135,7 +136,9 @@ class ConjureUnionType(ConjureType):
         return {}
 
     def __hash__(self):
-        values = tuple([getattr(self, attr) for attr, field_def in self._options().items()])
+        values = tuple([getattr(self, attr) for
+                        attr, field_def in
+                        self._options().items()])
         return hash(values)
 
     def __eq__(self, other):

--- a/conjure_python_client/_lib/types.py
+++ b/conjure_python_client/_lib/types.py
@@ -38,12 +38,15 @@ class ListType(ConjureType):
 
 
 class SetType(ConjureType):
-    item_type = None  # type: Type[DecodableType]
+    _item_type = None  # type: Type[DecodableType]
 
     def __init__(self, item_type):
         # type: (Type[DecodableType]) -> None
-        self.item_type = item_type
+        self._item_type = item_type
 
+    @property
+    def item_type(self):
+        return self._item_type
 
 class DictType(ConjureType):
     key_type = None  # type: Type[DecodableType]

--- a/conjure_python_client/_lib/types.py
+++ b/conjure_python_client/_lib/types.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Dict, Type, Any, Union
+from typing import List, Dict, Type, Any, Union, FrozenSet
 from enum import Enum
 
 from .case import to_snake_case
@@ -24,11 +24,19 @@ class ConjureType(object):
 
 
 DecodableType = Union[
-    int, float, bool, str, ConjureType, List[Any], Dict[Any, Any]
+    int, float, bool, str, ConjureType, List[Any], Dict[Any, Any], FrozenSet[Any]
 ]
 
 
 class ListType(ConjureType):
+    item_type = None  # type: Type[DecodableType]
+
+    def __init__(self, item_type):
+        # type: (Type[DecodableType]) -> None
+        self.item_type = item_type
+
+
+class SetType(ConjureType):
     item_type = None  # type: Type[DecodableType]
 
     def __init__(self, item_type):
@@ -78,6 +86,11 @@ class ConjureBeanType(ConjureType):
         name to the field definition"""
         return {}
 
+    def __hash__(self):
+        values_tuple = tuple(self._fields().values())
+        keys_tuple = tuple(self._fields().keys())
+        return hash((values_tuple, keys_tuple))
+
     def __eq__(self, other):
         # type: (Any) -> bool
         if not isinstance(other, self.__class__):
@@ -121,6 +134,10 @@ class ConjureUnionType(ConjureType):
         to the field definition for that type"""
         return {}
 
+    def __hash__(self):
+        values = tuple([getattr(self, attr) for attr, field_def in self._options().items()])
+        return hash(values)
+
     def __eq__(self, other):
         # type: (Any) -> bool
         if not isinstance(other, self.__class__):
@@ -129,9 +146,9 @@ class ConjureUnionType(ConjureType):
         assert isinstance(other, ConjureUnionType)
 
         pythonic_sanitized_identifier = \
-            sanitize_identifier(to_snake_case(self.type))
+            sanitize_identifier(to_snake_case(self._type))
 
-        return other.type == self.type and \
+        return other._type == self._type and \
             getattr(self, pythonic_sanitized_identifier) == \
             getattr(other, pythonic_sanitized_identifier)
 

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -64,7 +64,7 @@ class ConjureDecoder(object):
         print field_definition
         if isinstance(field_definition.field_type, ListType):
             deserialized[python_arg_name] = []
-        if isinstance(field_definition.field_type, SetType):
+        elif isinstance(field_definition.field_type, SetType):
             deserialized[python_arg_name] = []
         elif isinstance(field_definition.field_type, DictType):
             deserialized[python_arg_name] = {}

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -102,7 +102,10 @@ class ConjureDecoder(object):
 
         deserialized = {}  # type: Dict[str, Any]
         if type_of_union not in obj or obj[type_of_union] is None:
-            cls.check_null_field(obj, deserialized, attr, conjure_field_definition)
+            cls.check_null_field(obj,
+                                 deserialized,
+                                 attr,
+                                 conjure_field_definition)
         else:
             value = obj[type_of_union]
             field_type = conjure_field_definition.field_type

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -61,7 +61,6 @@ class ConjureDecoder(object):
     @classmethod
     def check_null_field(
             cls, obj, deserialized, python_arg_name, field_definition):
-        print field_definition
         if isinstance(field_definition.field_type, ListType):
             deserialized[python_arg_name] = []
         elif isinstance(field_definition.field_type, SetType):

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -70,7 +70,7 @@ class ConjureDecoder(object):
         elif isinstance(field_definition.field_type, OptionalType):
             deserialized[python_arg_name] = None
         else:
-            raise Exception(
+            raise ValueError(
                 "field {} not found in object {}".format(
                     field_definition.identifier, obj
                 )
@@ -150,7 +150,7 @@ class ConjureDecoder(object):
             and the values are of type value_type.
         """
         if not isinstance(obj, dict):
-            raise Exception("expected a python dict")
+            raise TypeError("expected a python dict")
 
         return dict(
             map(
@@ -176,7 +176,7 @@ class ConjureDecoder(object):
                 element_type.
         """
         if not isinstance(obj, list):
-            raise Exception("expected a python list")
+            raise TypeError("expected a python list")
 
         return list(map(lambda x: cls.do_decode(x, element_type), obj))
 
@@ -194,7 +194,7 @@ class ConjureDecoder(object):
                 element_type.
         """
         if not isinstance(obj, list):
-            raise Exception("expected a python list")
+            raise TypeError("expected a python list")
 
         return frozenset(map(lambda x: cls.do_decode(x, element_type), obj))
 
@@ -219,7 +219,7 @@ class ConjureDecoder(object):
     @classmethod
     def decode_primitive(cls, obj, object_type):
         def raise_mismatch():
-            raise Exception(
+            raise TypeError(
                 'Expected to find {} type but found {} instead'.format(
                     object_type, type(obj)))
 

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -124,7 +124,7 @@ class ConjureDecoder(object):
             An instance of enum of type conjure_type.
         """
         if not (isinstance(obj, str) or str(type(obj)) == "<type 'unicode'>"):
-            raise Exception(
+            raise TypeError(
                 'Expected to find str type but found {} instead'.format(
                     type(obj)))
 

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -19,10 +19,11 @@ from .._lib import (
     ConjureUnionType,
     DictType,
     ListType,
-    OptionalType
+    OptionalType,
+    SetType
 )
 from typing import Optional
-from typing import Dict, Any, List
+from typing import Dict, Any, List, FrozenSet
 import inspect
 import json
 
@@ -60,7 +61,10 @@ class ConjureDecoder(object):
     @classmethod
     def check_null_field(
             cls, obj, deserialized, python_arg_name, field_definition):
+        print field_definition
         if isinstance(field_definition.field_type, ListType):
+            deserialized[python_arg_name] = []
+        if isinstance(field_definition.field_type, SetType):
             deserialized[python_arg_name] = []
         elif isinstance(field_definition.field_type, DictType):
             deserialized[python_arg_name] = {}
@@ -99,7 +103,7 @@ class ConjureDecoder(object):
 
         deserialized = {}  # type: Dict[str, Any]
         if type_of_union not in obj or obj[type_of_union] is None:
-            cls.check_null_field(obj, deserialized, conjure_field_definition)
+            cls.check_null_field(obj, deserialized, attr, conjure_field_definition)
         else:
             value = obj[type_of_union]
             field_type = conjure_field_definition.field_type
@@ -175,6 +179,24 @@ class ConjureDecoder(object):
         return list(map(lambda x: cls.do_decode(x, element_type), obj))
 
     @classmethod
+    def decode_set(cls, obj, element_type):
+        # type: (List[Any], ConjureTypeType) -> FrozenSet[Any]
+        """Decodes json into a frozenset, handling conversion of the elements.
+
+        Args:
+            obj: the json object to decode
+            element_type: a class object which is the conjure type of
+                the elements in this list.
+        Returns:
+            A python frozenset where the elements are instances of type
+                element_type.
+        """
+        if not isinstance(obj, list):
+            raise Exception("expected a python list")
+
+        return frozenset(map(lambda x: cls.do_decode(x, element_type), obj))
+
+    @classmethod
     def decode_optional(cls, obj, object_type):
         # type: (Optional[Any], ConjureTypeType) -> Optional[Any]
         """Decodes json into an element, returning None if the provided object
@@ -243,6 +265,9 @@ class ConjureDecoder(object):
 
         elif isinstance(obj_type, OptionalType):
             return cls.decode_optional(obj, obj_type.item_type)
+
+        elif isinstance(obj_type, SetType):
+            return cls.decode_set(obj, obj_type.item_type)
 
         return cls.decode_primitive(obj, obj_type)
 

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -64,7 +64,7 @@ class ConjureDecoder(object):
         if isinstance(field_definition.field_type, ListType):
             deserialized[python_arg_name] = []
         elif isinstance(field_definition.field_type, SetType):
-            deserialized[python_arg_name] = []
+            deserialized[python_arg_name] = frozenset()
         elif isinstance(field_definition.field_type, DictType):
             deserialized[python_arg_name] = {}
         elif isinstance(field_definition.field_type, OptionalType):
@@ -193,8 +193,8 @@ class ConjureDecoder(object):
             A python frozenset where the elements are instances of type
                 element_type.
         """
-        if not isinstance(obj, list):
-            raise TypeError("expected a python list")
+        if not isinstance(obj, (list, set, frozenset)):
+            raise TypeError("expected a python list, set or frozenset")
 
         return frozenset(map(lambda x: cls.do_decode(x, element_type), obj))
 

--- a/conjure_python_client/_serde/encoder.py
+++ b/conjure_python_client/_serde/encoder.py
@@ -75,9 +75,7 @@ class ConjureEncoder(json.JSONEncoder):
         elif isinstance(obj, ConjureEnumType):
             return obj.value
 
-        elif isinstance(obj, list) \
-             or isinstance(obj, frozenset) \
-             or isinstance(obj, set):
+        elif isinstance(obj, (set, frozenset, list)):
             return list(map(cls.do_encode, obj))
 
         elif isinstance(obj, dict):

--- a/conjure_python_client/_serde/encoder.py
+++ b/conjure_python_client/_serde/encoder.py
@@ -75,7 +75,9 @@ class ConjureEncoder(json.JSONEncoder):
         elif isinstance(obj, ConjureEnumType):
             return obj.value
 
-        elif isinstance(obj, list) or isinstance(obj, frozenset) or isinstance(obj, set):
+        elif isinstance(obj, list) \
+             or isinstance(obj, frozenset) \
+             or isinstance(obj, set):
             return list(map(cls.do_encode, obj))
 
         elif isinstance(obj, dict):

--- a/conjure_python_client/_serde/encoder.py
+++ b/conjure_python_client/_serde/encoder.py
@@ -75,7 +75,7 @@ class ConjureEncoder(json.JSONEncoder):
         elif isinstance(obj, ConjureEnumType):
             return obj.value
 
-        elif isinstance(obj, list):
+        elif isinstance(obj, list) or isinstance(obj, frozenset) or isinstance(obj, set):
             return list(map(cls.do_encode, obj))
 
         elif isinstance(obj, dict):

--- a/test/serde/test_decode_enum.py
+++ b/test/serde/test_decode_enum.py
@@ -12,27 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ._serde import *
-from ._http import *
-from ._lib import *
-from ._version import __version__
+import pytest
+from conjure_python_client import ConjureDecoder, ConjureEnumType
 
-__all__ = [
-    'BinaryType',
-    'ConjureBeanType',
-    'ConjureDecoder',
-    'ConjureEncoder',
-    'ConjureEnumType',
-    'ConjureFieldDefinition',
-    'ConjureType',
-    'ConjureUnionType',
-    'DecodableType',
-    'DictType',
-    'ListType',
-    'OptionalType',
-    'RequestsClient',
-    'Service',
-    'ServiceConfiguration',
-    'SetType',
-    'SslConfiguration',
-]
+
+class TestEnum(ConjureEnumType):
+    A = 1
+    B = 2
+    C = 3
+
+def test_enum_decode():
+    decoded_A = ConjureDecoder().read_from_string("\"A\"", TestEnum)
+    decoded_B = ConjureDecoder().read_from_string("\"B\"", TestEnum)
+    decoded_A2 = ConjureDecoder().read_from_string("\"A\"", TestEnum)
+    assert decoded_A != decoded_B
+    assert decoded_A == decoded_A2
+
+
+
+

--- a/test/serde/test_decode_enum.py
+++ b/test/serde/test_decode_enum.py
@@ -42,5 +42,6 @@ def test_enum_decode():
     decoded_unk = ConjureDecoder().read_from_string("\"G\"", TestEnum)
     assert repr(decoded_unk) == "TestEnum.UNKNOWN"
 
-    decoded_integer = ConjureDecoder().read_from_string("5", TestEnum)
-    assert repr(decoded_integer) == "TestEnum.UNKNOWN"
+    with pytest.raises(TypeError):
+        decoded_integer = ConjureDecoder().read_from_string("5", TestEnum)
+

--- a/test/serde/test_decode_enum.py
+++ b/test/serde/test_decode_enum.py
@@ -1,3 +1,4 @@
+
 # (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,9 +18,19 @@ from conjure_python_client import ConjureDecoder, ConjureEnumType
 
 
 class TestEnum(ConjureEnumType):
-    A = 1
-    B = 2
-    C = 3
+
+    A = 'A'
+    '''A'''
+    B = 'B'
+    '''B'''
+    C = 'C'
+    '''C'''
+    UNKNOWN = 'UNKNOWN'
+    '''UNKNOWN'''
+
+    def __reduce_ex__(self, proto):
+        return self.__class__, (self.name,)
+
 
 def test_enum_decode():
     decoded_A = ConjureDecoder().read_from_string("\"A\"", TestEnum)
@@ -28,6 +39,8 @@ def test_enum_decode():
     assert decoded_A != decoded_B
     assert decoded_A == decoded_A2
 
+    decoded_unk = ConjureDecoder().read_from_string("\"G\"", TestEnum)
+    assert repr(decoded_unk) == "TestEnum.UNKNOWN"
 
-
-
+    decoded_integer = ConjureDecoder().read_from_string("5", TestEnum)
+    assert repr(decoded_integer) == "TestEnum.UNKNOWN"

--- a/test/serde/test_decode_object.py
+++ b/test/serde/test_decode_object.py
@@ -24,6 +24,7 @@ def test_object_decodes_when_exact_fields_are_present():
         """{"fileSystemId": "foo", "path": "bar"}""", CreateDatasetRequest
     )
     assert decoded == CreateDatasetRequest("foo", "bar")
+    assert hash(decoded) is not None
 
 
 def test_object_with_extra_fields_should_only_keep_expected_fields():
@@ -32,27 +33,31 @@ def test_object_with_extra_fields_should_only_keep_expected_fields():
         CreateDatasetRequest,
     )
     assert decoded == CreateDatasetRequest("foo", "bar")
+    assert hash(decoded) is not None
 
 
 def test_object_with_list_field_decodes():
     decoded = ConjureDecoder().read_from_string('{"value": []}', ListExample)
     assert decoded == ListExample([])
+    assert hash(decoded) is not None
 
 
 def test_object_with_omitted_list_field_decodes():
     decoded = ConjureDecoder().read_from_string('{}', ListExample)
     assert decoded == ListExample([])
+    assert hash(decoded) is not None
 
 
 def test_object_with_map_field_decodes():
     decoded = ConjureDecoder().read_from_string('{"value": {}}', MapExample)
     assert decoded == MapExample({})
+    assert hash(decoded) is not None
 
 
 def test_object_with_omitted_map_field_decodes():
     decoded = ConjureDecoder().read_from_string('{}', MapExample)
     assert decoded == MapExample({})
-
+    assert hash(decoded) is not None
 
 def test_object_with_missing_field_should_throw_helpful_exception():
     with pytest.raises(Exception) as excinfo:

--- a/test/serde/test_decode_set.py
+++ b/test/serde/test_decode_set.py
@@ -1,0 +1,53 @@
+# (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from conjure_python_client import ConjureDecoder, ConjureEncoder, SetType
+
+
+def test_set_with_well_typed_items_decodes():
+    decoded = ConjureDecoder().read_from_string("[1,2,3]", SetType(int))
+    assert type(decoded) is frozenset
+    assert type(list(decoded)[0]) is int
+
+
+def test_set_with_one_badly_typed_item_fails():
+    with pytest.raises(Exception):
+        ConjureDecoder().read_from_string("""[1,"two",3]""", SetType(int))
+
+
+def test_set_with_no_items_decodes():
+    decoded = ConjureDecoder().read_from_string("[]", SetType(int))
+    assert type(decoded) is frozenset
+
+
+def test_set_from_json_object_fails():
+    with pytest.raises(Exception):
+        ConjureDecoder().read_from_string("{}", SetType(int))
+
+
+def test_set_does_not_decode_from_json_null():
+    with pytest.raises(Exception):
+        ConjureDecoder().read_from_string("null", SetType(int))
+
+
+def test_set_does_not_decode_from_json_string():
+    with pytest.raises(Exception):
+        ConjureDecoder().read_from_string("\"hello\"", SetType(int))
+
+def test_set_encoder():
+    encoded = ConjureEncoder.do_encode(frozenset([5,6,7]))
+    assert type(encoded) is list
+    encoded = ConjureEncoder.do_encode(set([5,6,7]))
+    assert type(encoded) is list

--- a/test/serde/test_decode_union.py
+++ b/test/serde/test_decode_union.py
@@ -1,0 +1,72 @@
+# (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from conjure_python_client import ConjureDecoder, ListType, ConjureUnionType, ConjureFieldDefinition
+
+class TestUnion(ConjureUnionType):
+    _a = None
+    _b = None
+    _c = None
+
+    @classmethod
+    def _options(cls):
+        return {
+            'a': ConjureFieldDefinition('A', str),
+            'b': ConjureFieldDefinition('B', int),
+            'c': ConjureFieldDefinition('C', ListType(int))
+            }
+
+    def __init__(self, a=None, b=None, c=None):
+        if a is not None:
+            self._a = a
+            self._type = 'A'
+        elif b is not None:
+            self._b = b
+            self._type = 'B'
+        elif c is not None:
+            self._c = c
+            self._type = 'C'
+
+    @property
+    def a(self):
+        return self._a
+
+    @property
+    def b(self):
+        return self._b
+
+    @property
+    def c(self):
+        return self._c
+
+
+def test_union_decoder():
+    decoded_A = ConjureDecoder().read_from_string('{"type":"A", "A": "foo"}', TestUnion)
+    decoded_B = ConjureDecoder().read_from_string('{"type":"B", "B": 5}', TestUnion)
+    decoded_A2 = ConjureDecoder().read_from_string('{"type":"A", "A": "bar"}', TestUnion)
+    decoded_C = ConjureDecoder().read_from_string('{"type":"C"}', TestUnion)
+    assert type(decoded_A) is TestUnion
+    assert type(decoded_B) is TestUnion
+    assert type(decoded_C) is TestUnion
+    assert decoded_A != decoded_B
+    assert decoded_A != decoded_A2
+    assert decoded_C != decoded_A
+    assert not decoded_C.c
+
+def test_invalid_decode():
+    with pytest.raises(Exception):
+        decoded_invalid = ConjureDecoder().read_from_string('{"type":"A", "B": "bar"}', TestUnion)
+    
+


### PR DESCRIPTION

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
- Comparison of Union types was broken
- No tests for enum or union types
- No way to represent Sets separate from Lists

## After this PR
This PR does a few things:
- fixes and tests https://github.com/palantir/conjure-python-client/issues/17
- adds tests for the union and enum types which had bugs before
- adds a SetType for the eventual native support for frozenset to resolve https://github.com/palantir/conjure-python/issues/27 later


<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
