### PR TITLE
[improvement] implement connect and read timeouts

### DIFF
--- a/conjure_python_client/_http/configuration.py
+++ b/conjure_python_client/_http/configuration.py
@@ -26,9 +26,8 @@ class SslConfiguration(object):
 class ServiceConfiguration(object):
     api_token = None  # type: str
     security = SslConfiguration  # type: Any
-    connect_timeout = None  # type: int
-    read_timeout = None  # type: int
-    write_timeout = None  # type: int
+    connect_timeout = 10  # type: float
+    read_timeout = 300  # type: float
     uris = []  # type: List[str]
     max_num_retries = 3  # type: int
     backoff_slot_size = 500  # type: int

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -52,7 +52,7 @@ class Service(object):
     def __init__(
         self, requests_session, uris, _connect_timeout, _read_timeout
     ):
-        # type: (requests.Session, List[str]) -> None
+        # type: (requests.Session, List[str], float, float) -> None
         self._requests_session = requests_session
         self._uris = uris
         self._connect_timeout = _connect_timeout

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -119,7 +119,7 @@ class RequestsClient(object):
         for uri in service_config.uris:
             session.mount(uri, transport_adapter)
         return service_class(
-            session, 
+            session,
             service_config.uris,
             service_config.connect_timeout,
             service_config.read_timeout

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -118,12 +118,12 @@ class RequestsClient(object):
             session.verify = service_config.security.trust_store_path
         for uri in service_config.uris:
             session.mount(uri, transport_adapter)
-        return service_class(
+        return service_class(  # type: ignore
             session,
             service_config.uris,
             service_config.connect_timeout,
             service_config.read_timeout
-        )  # type: ignore
+        )
 
 
 class TransportAdapter(HTTPAdapter):

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -46,10 +46,12 @@ CIPHERS = (
 class Service(object):
     _requests_session = None  # type: requests.Session
     _uris = None  # type: List[str]
-    _connect_timeout = None # type: float
-    _read_timeout = None # type: float
+    _connect_timeout = None  # type: float
+    _read_timeout = None  # type: float
 
-    def __init__(self, requests_session, uris, _connect_timeout, _read_timeout):
+    def __init__(
+        self, requests_session, uris, _connect_timeout, _read_timeout
+    ):
         # type: (requests.Session, List[str]) -> None
         self._requests_session = requests_session
         self._uris = uris
@@ -76,7 +78,7 @@ class Service(object):
                     cleaned_params[key] = str(value).lower() \
                         if isinstance(value, bool) else str(value)
                 kwargs[param_kind] = cleaned_params
-        
+
         kwargs['timeout'] = (self._connect_timeout, self._read_timeout)
 
         _response = self._requests_session.request(*args, **kwargs)
@@ -118,8 +120,8 @@ class RequestsClient(object):
             session.mount(uri, transport_adapter)
         return service_class(
             session, 
-            service_config.uris, 
-            service_config.connect_timeout, 
+            service_config.uris,
+            service_config.connect_timeout,
             service_config.read_timeout
         )  # type: ignore
 


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
The python client does not implement any read or connect timeouts. The existing configuration values for this is just ignored.

## After this PR
<!-- Describe at a high-level why this approach is better. -->
It's possible to configure connect and read timeouts. The default configuration has been changed to match https://github.com/palantir/conjure-java-runtime/.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
