### PR TITLE
[improvement] bring backoff defaults in line with java client

### DIFF
--- a/conjure_python_client/_http/configuration.py
+++ b/conjure_python_client/_http/configuration.py
@@ -29,5 +29,5 @@ class ServiceConfiguration(object):
     connect_timeout = 10  # type: float
     read_timeout = 300  # type: float
     uris = []  # type: List[str]
-    max_num_retries = 3  # type: int
-    backoff_slot_size = 500  # type: int
+    max_num_retries = 4  # type: int
+    backoff_slot_size = 250  # type: int


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
The python client had different default settings to the java client.

## After this PR
<!-- Describe at a high-level why this approach is better. -->
Unless we have a good reason otherwise, we should aim for unity between the clients. N.b. given we both increase timeouts by 1 but half the initial wait duration, the overall amount of time we spend retrying here remains the same.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
