### PR TITLE
[improvement] change retry logic to include a uniform jitter

### DIFF
--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -98,6 +98,11 @@ class Service(object):
         )
 
 
+class RetryWithJitter(Retry):
+    def get_backoff_time(self):
+        return random.random() * super(RetryWithJitter, self).get_backoff_time()
+
+
 class RequestsClient(object):
 
     @classmethod
@@ -105,7 +110,7 @@ class RequestsClient(object):
         # type: (Type[T], str, ServiceConfiguration) -> T
         # setup retry to match java remoting
         # https://github.com/palantir/http-remoting/tree/3.12.0#quality-of-service-retry-failover-throttling
-        retry = Retry(
+        retry = RetryWithJitter(
             total=service_config.max_num_retries,
             status_forcelist=[308, 429, 503],
             backoff_factor=float(service_config.backoff_slot_size) / 1000,

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -100,7 +100,8 @@ class Service(object):
 
 class RetryWithJitter(Retry):
     def get_backoff_time(self):
-        return random.random() * super(RetryWithJitter, self).get_backoff_time()
+        jitter = random.random()
+        return jitter * super(RetryWithJitter, self).get_backoff_time()
 
 
 class RequestsClient(object):


### PR DESCRIPTION
## Before this PR
Retry backoff times were strictly exponential. This can lead to problems where retries from a number of clients cluster, meaning the backoff logic doesn't reduce contention all that much.

## After this PR
Retry backoff times now include a uniform jitter. This brings this client into line with the [java conjure client](https://github.com/palantir/conjure-java-runtime/blob/706a47c674fd4db23cddd00515f58e19e9b48069/okhttp-clients/src/main/java/com/palantir/conjure/java/okhttp/ExponentialBackoff.java).

For more information: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/