### PR TITLE
[improvement] include fresh trace id per request

### DIFF
--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -14,7 +14,6 @@
 
 from requests.adapters import HTTPAdapter
 from typing import TypeVar, Type, List, Optional, Dict
-from typing_extensions import Final
 from requests.exceptions import HTTPError
 from requests.packages.urllib3.poolmanager import PoolManager
 from requests.packages.urllib3.util.ssl_ import create_urllib3_context
@@ -44,7 +43,7 @@ CIPHERS = (
 )
 
 
-TRACE_ID_HEADER = 'X-B3-TraceId' # type: Final[str]
+TRACE_ID_HEADER = 'X-B3-TraceId' # type: str
 
 
 def fresh_trace_id():

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -43,6 +43,12 @@ CIPHERS = (
 )
 
 
+def fresh_trace_id():
+    # type: () -> str
+    # returns a string which is a valid zipkin trace id
+    return '{:02x}'.format(random.getrandbits(64))
+
+
 class Service(object):
     _requests_session = None  # type: requests.Session
     _uris = None  # type: List[str]
@@ -80,6 +86,10 @@ class Service(object):
                 kwargs[param_kind] = cleaned_params
 
         kwargs['timeout'] = (self._connect_timeout, self._read_timeout)
+
+        if 'headers' not in kwargs:
+            kwargs['headers'] = {}
+        kwargs['headers']['X-B3-TraceId'] = fresh_trace_id()
 
         _response = self._requests_session.request(*args, **kwargs)
         try:

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from requests.adapters import HTTPAdapter
-from typing import TypeVar, Type, List, Optional, Dict
+from typing import TypeVar, Type, List, Optional, Dict, Final
 from requests.exceptions import HTTPError
 from requests.packages.urllib3.poolmanager import PoolManager
 from requests.packages.urllib3.util.ssl_ import create_urllib3_context
@@ -41,6 +41,9 @@ CIPHERS = (
     "AES128-SHA:"
     "TLS_FALLBACK_SCSV"
 )
+
+
+TRACE_ID_HEADER = 'X-B3-TraceId' # type: Final[str]
 
 
 def fresh_trace_id():
@@ -89,7 +92,7 @@ class Service(object):
 
         if 'headers' not in kwargs:
             kwargs['headers'] = {}
-        kwargs['headers']['X-B3-TraceId'] = fresh_trace_id()
+        kwargs['headers'][TRACE_ID_HEADER] = fresh_trace_id()
 
         _response = self._requests_session.request(*args, **kwargs)
         try:

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -43,7 +43,7 @@ CIPHERS = (
 )
 
 
-TRACE_ID_HEADER = 'X-B3-TraceId' # type: str
+TRACE_ID_HEADER = 'X-B3-TraceId'  # type: str
 
 
 def fresh_trace_id():

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 from requests.adapters import HTTPAdapter
-from typing import TypeVar, Type, List, Optional, Dict, Final
+from typing import TypeVar, Type, List, Optional, Dict
+from typing_extensions import Final
 from requests.exceptions import HTTPError
 from requests.packages.urllib3.poolmanager import PoolManager
 from requests.packages.urllib3.util.ssl_ import create_urllib3_context

--- a/test/test_http.py
+++ b/test/test_http.py
@@ -134,3 +134,12 @@ class TestHttpRemoting(object):
         with pytest.raises(ConjureHTTPError) as e:
             self._test_service().testEndpoint('foo')
         assert e.match("mocked http error. TraceId: 'faketraceid'. Response: ''")
+
+    @mock.patch('requests.Session.request')
+    def test_request_trace_id(self, mock_request):
+        mock_request.return_value = self._mock_response(json_data='bar')
+        self._test_service().testEndpoint('foo')
+
+        call = mock_request.mock_calls[0]
+        call_kwargs = call[2]
+        assert 'X-B3-TraceId' in call_kwargs['headers']

--- a/test/test_http.py
+++ b/test/test_http.py
@@ -143,3 +143,12 @@ class TestHttpRemoting(object):
         call = mock_request.mock_calls[0]
         call_kwargs = call[2]
         assert 'X-B3-TraceId' in call_kwargs['headers']
+        first_trace = call_kwargs['headers']['X-B3-TraceId']
+
+        mock_request.reset_mock()
+        self._test_service().testEndpoint('foo')
+
+        second_call = mock_request.mock_calls[0]
+        second_trace = second_call[2]['headers']['X-B3-TraceId']
+
+        assert first_trace != second_trace


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
When retrying, there was no way to associate the remote calls resulting from a 'single' client call.

## After this PR
We create a traceid per request and pass this in the `X-B3-TraceId` header. Retries will preserve this trace id.

In the future we may want to take a more heavyweight approach - i.e. a python implementation of [tracing-java](https://github.com/palantir/tracing-java) or use an existing open-source python tracing library such as https://github.com/lookfwd/zipkin-python-opentracing 
