### PR TITLE
[fix] Use system randomness (urandom) for traces

### DIFF
--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -51,8 +51,8 @@ TRACE_ID_RANDOM_BYTES = 8
 
 
 def fresh_trace_id():
-    # type: () -> str
-    # returns a string which is a valid zipkin trace id
+    # type: () -> bytes
+    # returns a bytestring which is a valid zipkin trace id
     return binascii.hexlify(os.urandom(TRACE_ID_RANDOM_BYTES))
 
 

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -23,6 +23,7 @@ from future.utils import raise_from
 
 import binascii
 import os
+import random
 import requests
 
 
@@ -74,7 +75,7 @@ class Service(object):
     def _uri(self):
         # type: () -> str
         """returns a random uri"""
-        return random.choice(self._uris)
+        return random.SystemRandom().choice(self._uris)
 
     def _request(self, *args, **kwargs):
         # type (Any) -> Response

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -20,8 +20,10 @@ from requests.packages.urllib3.util.ssl_ import create_urllib3_context
 from requests.packages.urllib3.util import Retry
 from .configuration import ServiceConfiguration
 from future.utils import raise_from
+
+import binascii
+import os
 import requests
-import random
 
 
 T = TypeVar("T")
@@ -44,12 +46,13 @@ CIPHERS = (
 
 
 TRACE_ID_HEADER = 'X-B3-TraceId'  # type: str
+TRACE_ID_RANDOM_BYTES = 8
 
 
 def fresh_trace_id():
     # type: () -> str
     # returns a string which is a valid zipkin trace id
-    return '{:02x}'.format(random.getrandbits(64))
+    return binascii.hexlify(os.urandom(TRACE_ID_RANDOM_BYTES))
 
 
 class Service(object):


### PR DESCRIPTION
Internal products that manage python execution often fork executors
from a long-running python process. This means the executors start with
the same python random generator state, and will therefore generate the
same traceids.

## Before this PR
Duplicate traceids would be generated in processes that fork before making requests, and don't explicitly move the random generator forward.

## After this PR
Traceids are sourced from system randomness, and so will not share state between process forks.