### PR TITLE
do not retry on read errors

### DIFF
--- a/changelog/@unreleased/pr-84.v2.yml
+++ b/changelog/@unreleased/pr-84.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Do not retry on read errors.
+  links:
+  - https://github.com/palantir/conjure-python-client/pull/84

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -157,6 +157,7 @@ class RequestsClient(object):
         # https://github.com/palantir/http-remoting/tree/3.12.0#quality-of-service-retry-failover-throttling
         retry = RetryWithJitter(
             total=service_config.max_num_retries,
+            read=0, # do not retry read errors
             status_forcelist=[308, 429, 503],
             backoff_factor=float(service_config.backoff_slot_size) / 1000,
         )

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -157,7 +157,7 @@ class RequestsClient(object):
         # https://github.com/palantir/http-remoting/tree/3.12.0#quality-of-service-retry-failover-throttling
         retry = RetryWithJitter(
             total=service_config.max_num_retries,
-            read=0, # do not retry read errors
+            read=0,  # do not retry read errors
             status_forcelist=[308, 429, 503],
             backoff_factor=float(service_config.backoff_slot_size) / 1000,
         )


### PR DESCRIPTION
## Before this PR
We would retry on things like connection timeouts.

Additionally since we make no idempotence guarantees in conjure endpoints, we would retry where it's actually not safe to do so.

## After this PR
This brings conjure-python-client in line with the behaviour of the java client introduced in https://github.com/palantir/conjure-java-runtime/pull/1085.

==COMMIT_MSG==
Do not retry on read errors.
==COMMIT_MSG==

## Possible downsides?
Existing users may be relying on this behaviour of automatic retrying on read timeout - perhaps they're using conjure-python-client over an unreliable network.
