### PR TITLE
Restrict enum34 and typing intallation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: pip install --user setuptools tox==2.9.1 tox-virtualenv-no-download
+          command: pip install --user -U setuptools tox==2.9.1 tox-virtualenv-no-download
 
       - restore_cache:
           key: tox-v2-py27-{{ checksum "tox.ini" }}-({ checksum "Pipfile.lock" })
@@ -71,7 +71,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: pip install --user setuptools tox==2.9.1 tox-virtualenv-no-download
+          command: pip install --user -U setuptools tox==2.9.1 tox-virtualenv-no-download
 
       - restore_cache:
           key: tox-v2-py3-{{ checksum "tox.ini" }}-({ checksum "Pipfile.lock" })
@@ -103,7 +103,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: pip install --user setuptools tox==2.9.1 tox-virtualenv-no-download
+          command: pip install --user -U setuptools tox==2.9.1 tox-virtualenv-no-download
 
       - restore_cache:
           key: tox-v2-mypy27-{{ checksum "tox.ini" }}-({ checksum "Pipfile.lock" })
@@ -135,7 +135,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: pip install --user setuptools tox==2.9.1 tox-virtualenv-no-download
+          command: pip install --user -U setuptools tox==2.9.1 tox-virtualenv-no-download
 
       - restore_cache:
           key: tox-v2-mypy3-{{ checksum "tox.ini" }}-({ checksum "Pipfile.lock" })
@@ -167,7 +167,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: pip install --user setuptools tox==2.9.1 tox-virtualenv-no-download
+          command: pip install --user -U setuptools tox==2.9.1 tox-virtualenv-no-download
 
       - restore_cache:
           key: tox-v2-lint-{{ checksum "tox.ini" }}-({ checksum "Pipfile.lock" })

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,11 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=["enum34", "future", "requests", "typing"],
+    install_requires=["future", "requests"],
+    extras_require={
+        ':python_version<"3.4"': ['enum34'],
+        ':python_version<"3.5"': ['typing']
+    },
     tests_require=["pytest", "pyyaml"],
     cmdclass={"format": FormatCommand},
 )


### PR DESCRIPTION
`enum34` backports the enum functionality delivered in python 3.4 to older versions of
python.  Limit it's installation to only those earlier versions.

Similarly `typing` became part of the stdlib in 3.5.  Restrict its installation to only earlier
python versions.

In both instances, without this restriction, the installed packages overshadow stdlib
modules, resulting in undesired behaviour (such as the disappearence of newer
features).

## Before this PR
`enum34` and `typing` are installed regardless of python version, potentially overshadowing the stdlib.

## After this PR
Those dependencies are only installed when needed.
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

