### PR TITLE
Fix bug in _clean_param_value that would break on array query parameters

### DIFF
--- a/changelog/@unreleased/pr-101.v2.yml
+++ b/changelog/@unreleased/pr-101.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: List query parameters are now passed correctly
+  links:
+  - https://github.com/palantir/conjure-python-client/pull/101

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -123,6 +123,8 @@ def _clean_params(params):
 
 
 def _clean_param_value(value):
+    if isinstance(value, list):
+        return [_clean_param_value(element) for element in value]
     if isinstance(value, bool):
         return str(value).lower()
     return str(value)

--- a/test/example_service/product/__init__.py
+++ b/test/example_service/product/__init__.py
@@ -51,8 +51,8 @@ class CreateDatasetRequest(ConjureBeanType):
 
 class SimpleService(Service):
 
-    def testEndpoint(self, string):
-        # type: (str) -> str
+    def testEndpoint(self, string, decoration=[]):
+        # type: (str, List[str]) -> str
 
         _headers = {
             'Accept': 'application/json',
@@ -60,6 +60,7 @@ class SimpleService(Service):
         } # type: Dict[str, Any]
 
         _params = {
+            "decoration": decoration
         } # type: Dict[str, Any]
 
         _path_params = {

--- a/test/test_http.py
+++ b/test/test_http.py
@@ -58,6 +58,13 @@ class TestHttpRemoting(object):
         self._test_service().testEndpoint('foo')
 
     @mock.patch('requests.Session.request')
+    def test_array_query_parameter(self, mock_request):
+        mock_request.return_value = self._mock_response(json_data='bar')
+        self._test_service().testEndpoint('foo', decoration=['branches', 'path'])
+        name, args, kwargs = mock_request.mock_calls[0]
+        assert kwargs["params"]["decoration"] == ['branches', 'path']
+
+    @mock.patch('requests.Session.request')
     def test_http_error(self, mock_request):
         resp = requests.Response()
         resp.status_code = 404


### PR DESCRIPTION
## Before this PR
Array query parameters did not work (they would be converted into strings instead of passed as arrays).

## After this PR
Array query parameters do work.

## Possible downsides?
Technically, _clean_param_value gets called with `params` and with `header` parameters, but we only actually need this behavior with `params`. We could be stricter about distinguishing those cases, but in practice passing an array for a header parameter isn't a case that we should need to worry about one way or the other because that's always incorrect client behavior (i.e., the original behavior of converting the passed array into a string was also not going to produce a valid request).