### PR TITLE
Add type_of_union to check_null_field when decoding union types.

### DIFF
--- a/changelog/@unreleased/pr-106.v2.yml
+++ b/changelog/@unreleased/pr-106.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Add missing type_of_union to check_null_field when decoding union types.
+  links:
+  - https://github.com/palantir/conjure-python-client/pull/106

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -99,7 +99,8 @@ class ConjureDecoder(object):
 
         deserialized = {}  # type: Dict[str, Any]
         if type_of_union not in obj or obj[type_of_union] is None:
-            cls.check_null_field(obj, deserialized, type_of_union, conjure_field_definition)
+            cls.check_null_field(
+                obj, deserialized, type_of_union, conjure_field_definition)
         else:
             value = obj[type_of_union]
             field_type = conjure_field_definition.field_type

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -99,7 +99,7 @@ class ConjureDecoder(object):
 
         deserialized = {}  # type: Dict[str, Any]
         if type_of_union not in obj or obj[type_of_union] is None:
-            cls.check_null_field(obj, deserialized, conjure_field_definition)
+            cls.check_null_field(obj, deserialized, type_of_union, conjure_field_definition)
         else:
             value = obj[type_of_union]
             field_type = conjure_field_definition.field_type


### PR DESCRIPTION
## Before this PR
check_null_field takes 4 args and only 3 are being passed when decoding union types.

