### PR TITLE
add py.typed marker

### DIFF
--- a/changelog/@unreleased/pr-109.v2.yml
+++ b/changelog/@unreleased/pr-109.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add py.typed marker
+  links:
+  - https://github.com/palantir/conjure-python-client/pull/109

--- a/scripts/download_test_server.sh
+++ b/scripts/download_test_server.sh
@@ -14,7 +14,6 @@ mkdir -p "$DOWNLOADS_DIR"/bin
 mkdir -p "$RESOURCES_DIR"
 
 function download() {
-  echo "Downloading $1"
   basename=$(basename "$1")
   target="$DOWNLOADS_DIR"/"$basename"
   if [[ ! -f "$target" ]]; then

--- a/scripts/download_test_server.sh
+++ b/scripts/download_test_server.sh
@@ -14,6 +14,7 @@ mkdir -p "$DOWNLOADS_DIR"/bin
 mkdir -p "$RESOURCES_DIR"
 
 function download() {
+  echo "Downloading $1"
   basename=$(basename "$1")
   target="$DOWNLOADS_DIR"/"$basename"
   if [[ ! -f "$target" ]]; then

--- a/setup.py
+++ b/setup.py
@@ -90,4 +90,7 @@ setup(
     tests_require=["pytest", "pyyaml"],
     python_requires=">=3.8",
     cmdclass={"format": FormatCommand},
+    package_data = {
+        'conjure_python_client': ['py.typed'],
+    },
 )


### PR DESCRIPTION
## Before this PR
```
my_local_thing/handler.py:3: error: Skipping analyzing "conjure_python_client": module is installed, but missing library stubs or py.typed marker
```

I also used @JacekLach's https://github.com/palantir/conjure-python/pull/471/files as a ref

## After this PR

Via https://www.python.org/dev/peps/pep-0561/ I think we just need to add the marker.

==COMMIT_MSG==
Add py.typed marker
==COMMIT_MSG==

