### PR TITLE
Use conjure-python 4.5.0-rc1

### DIFF
--- a/changelog/@unreleased/pr-121.v2.yml
+++ b/changelog/@unreleased/pr-121.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use conjure-python 4.5.0-rc1
+  links:
+  - https://github.com/palantir/conjure-python-client/pull/121

--- a/versions.props
+++ b/versions.props
@@ -1,2 +1,2 @@
-com.palantir.conjure.python:conjure-python = 3.17.0
+com.palantir.conjure.python:conjure-python = 4.5.0-rc1
 com.palantir.conjure.verification:* = 0.19.0


### PR DESCRIPTION
`4.5.0-rc1` requires only python 3.6 (vs 3.8). This is necessary for things like foundryts to upgrade to the latest `conjure-python-client` since many of the stemma repos in the wild set their `Run with` library to `3.6.*`