### PR TITLE
Enable passing a session in ServiceConfiguration

### DIFF
--- a/conjure_python_client/_http/configuration.py
+++ b/conjure_python_client/_http/configuration.py
@@ -14,6 +14,8 @@
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+import requests
+
 
 @dataclass
 class SslConfiguration:
@@ -24,6 +26,7 @@ class SslConfiguration:
 class ServiceConfiguration:
     api_token: Optional[str] = None
     security: Optional[SslConfiguration] = None
+    session: Optional[requests.Session] = None
     uris: List[str] = field(default_factory=list)
     connect_timeout: float = 10
     read_timeout: float = 300

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -168,9 +168,10 @@ class RequestsClient(object):
             backoff_factor=float(service_config.backoff_slot_size) / 1000,
         )
         transport_adapter = TransportAdapter(max_retries=retry)
-        # create a session, for shared connection polling, user agent, etc
-        session = requests.Session()
-        session.headers = CaseInsensitiveDict({"User-Agent": user_agent})
+        # create a session if one was not provided
+        if service_config.session is None:
+            session = requests.Session()
+        session.headers.update(CaseInsensitiveDict({"User-Agent": user_agent}))
         if service_config.security is not None:
             verify = service_config.security.trust_store_path
         else:

--- a/setup.py
+++ b/setup.py
@@ -79,12 +79,12 @@ setup(
     # The project's main homepage.
     url="https://github.com/palantir/conjure-python-client",
     author="Palantir Technologies, Inc.",
-    classifiers=[ 
+    classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10"
+        "Programming Language :: Python :: 3.10",
     ],
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
While the Service class uses a requests.Session object internally, there is no way to provide an existing Session object to the Service at initialization. This simply adds the ability to provide an existing session instead of always creating a new empty session

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
ServiceConfiguration objects may now contain a requests.Session object that will be inherited by clients initialized from the object

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
