### PR TITLE
Deserialize enum variants case-insensitively

### DIFF
--- a/changelog/@unreleased/pr-128.v2.yml
+++ b/changelog/@unreleased/pr-128.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Deserialize enum variants case-insensitively, for compatibility with
+    the Java implementation
+  links:
+  - https://github.com/palantir/conjure-python-client/pull/128

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -142,8 +142,9 @@ class ConjureDecoder(object):
                 )
             )
 
-        if obj in conjure_type.__members__:
-            return conjure_type[obj]
+        upper_value: str = obj.upper()
+        if upper_value in conjure_type.__members__:
+            return conjure_type[upper_value]
 
         else:
             return conjure_type["UNKNOWN"]

--- a/test/example_service/product/datasets/__init__.py
+++ b/test/example_service/product/datasets/__init__.py
@@ -129,7 +129,7 @@ class EnumExample(ConjureEnumType):
 
 class EnumFieldExample(ConjureBeanType):
 
-    @builtins.classmethod
+    @classmethod
     def _fields(cls) -> Dict[str, ConjureFieldDefinition]:
         return {
             'enum': ConjureFieldDefinition('enum', EnumExample)
@@ -140,6 +140,6 @@ class EnumFieldExample(ConjureBeanType):
     def __init__(self, enum: "EnumExample") -> None:
         self._enum = enum
 
-    @builtins.property
+    @property
     def enum(self) -> "EnumExample":
         return self._enum

--- a/test/example_service/product/datasets/__init__.py
+++ b/test/example_service/product/datasets/__init__.py
@@ -110,3 +110,36 @@ class MapExample(ConjureBeanType):
     @property
     def value(self) -> Dict[str, str]:
         return self._value
+
+
+class EnumExample(ConjureEnumType):
+
+    ONE = 'ONE'
+    '''ONE'''
+    TWO = 'TWO'
+    '''TWO'''
+    ONE_HUNDRED = 'ONE_HUNDRED'
+    '''ONE_HUNDRED'''
+    UNKNOWN = 'UNKNOWN'
+    '''UNKNOWN'''
+
+    def __reduce_ex__(self, proto):
+        return self.__class__, (self.name,)
+
+
+class EnumFieldExample(ConjureBeanType):
+
+    @builtins.classmethod
+    def _fields(cls) -> Dict[str, ConjureFieldDefinition]:
+        return {
+            'enum': ConjureFieldDefinition('enum', EnumExample)
+        }
+
+    __slots__: List[str] = ['_enum']
+
+    def __init__(self, enum: "EnumExample") -> None:
+        self._enum = enum
+
+    @builtins.property
+    def enum(self) -> "EnumExample":
+        return self._enum

--- a/test/serde/test_decode_object.py
+++ b/test/serde/test_decode_object.py
@@ -16,7 +16,7 @@ import pytest
 import re
 from conjure_python_client import ConjureDecoder
 from test.example_service.product import CreateDatasetRequest
-from test.example_service.product.datasets import ListExample, MapExample
+from test.example_service.product.datasets import EnumExample, EnumFieldExample, ListExample, MapExample
 
 
 def test_object_decodes_when_exact_fields_are_present():
@@ -52,6 +52,16 @@ def test_object_with_map_field_decodes():
 def test_object_with_omitted_map_field_decodes():
     decoded = ConjureDecoder().read_from_string("{}", MapExample)
     assert decoded == MapExample({})
+
+
+def test_object_with_enum_field_decodes():
+    decoded = ConjureDecoder().read_from_string('{"enum": "ONE"}', EnumFieldExample)
+    assert decoded == EnumFieldExample(EnumExample.ONE)
+
+
+def test_object_with_enum_field_decodes_case_insensitive():
+    decoded = ConjureDecoder().read_from_string('{"enum": "one"}', EnumFieldExample)
+    assert decoded == EnumFieldExample(EnumExample.ONE)
 
 
 def test_object_with_missing_field_should_throw_helpful_exception():


### PR DESCRIPTION
## Before this PR
The conjure spec requires that enum variants be uppercase. The [conjure wire spec](https://github.com/palantir/conjure/blob/master/docs/spec/wire.md) doesn't specify casing (as far as I saw). The Java implementation is case-insensitive on deserializing enum variants: https://github.com/palantir/conjure-java/blob/6.65.0/conjure-java-core/src/main/java/com/palantir/conjure/java/types/EnumGenerator.java#L240-L276. As such, some clients of conjure APIs currently use lower-case enum variants, which work with Java server implementations.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Deserialize enum variants case-insensitively, for compatibility with the Java implementation
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

