### PR TITLE
use pypi secrets rather than relying on custom TWINE_ env vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
           command: |
             pip install --user setuptools wheel twine
             python setup.py sdist bdist_wheel --universal
-            ~/.local/bin/twine upload dist/*
+            ~/.local/bin/twine upload --repository-url https://upload.pypi.org/legacy/ -u $PYPI_USERNAME -p $PYPI_PASSWORD dist/*
 
 workflows:
   version: 2

--- a/changelog/@unreleased/pr-135.v2.yml
+++ b/changelog/@unreleased/pr-135.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use injected PYPI_ secrets in twine publish.
+  links:
+  - https://github.com/palantir/conjure-python-client/pull/135


### PR DESCRIPTION
## Before this PR
We were relying on custom TWINE_ secrets in our circle publish.

## After this PR
==COMMIT_MSG==
Use injected PYPI_ secrets in twine publish.
==COMMIT_MSG==

