### PR TITLE
Fix: Do not overwrite the _version.py file if it already exists

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,22 +17,27 @@ from os import path, makedirs, system
 import subprocess
 import sys
 
-try:
-    gitversion = subprocess.check_output(
-        'git describe --tags --always --first-parent'.split()
-    ).decode(
-    ).strip(
-    ).replace(
-        '-', '_'
-    )
-    open("conjure_python_client/_version.py", "w").write(
-        '__version__ = "{}"\n'.format(gitversion)
-    )
-    if not path.exists("build"):
-        makedirs("build")
-except subprocess.CalledProcessError:
-    print("outside git repo, not generating new version string")
-exec (open("conjure_python_client/_version.py").read())
+
+VERSION_PY_PATH = "conjure_python_client/_version.py"
+
+
+if not path.exists(VERSION_PY_PATH):
+    try:
+        gitversion = subprocess.check_output(
+            'git describe --tags --always --first-parent'.split()
+        ).decode(
+        ).strip(
+        ).replace(
+            '-', '_'
+        )
+        open(VERSION_PY_PATH, "w").write(
+            '__version__ = "{}"\n'.format(gitversion)
+        )
+        if not path.exists("build"):
+            makedirs("build")
+    except subprocess.CalledProcessError:
+        print("outside git repo, not generating new version string")
+exec (open(VERSION_PY_PATH).read())
 
 
 class FormatCommand(Command):


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Everytime the package is installed, the script runs to determine the current version using git, if git is installed.

This has been causing problems in the conda-forge feedstock of this repo as it's not actually cloning the source code, but rather working off of the pypi distribution of this repo, hence overwriting it with a non-PEP440-compliant version and causing problems for consumers.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Do not overwrite the _version.py file if it already exists
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
