### PR TITLE
Fix: Do not overwrite the _version.py file if it already exists

### DIFF
--- a/changelog/@unreleased/pr-140.v2.yml
+++ b/changelog/@unreleased/pr-140.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Do not overwrite the _version.py file if it already exists
+  links:
+  - https://github.com/palantir/conjure-python-client/pull/140

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if not path.exists(VERSION_PY_PATH):
             makedirs("build")
     except subprocess.CalledProcessError:
         print("outside git repo, not generating new version string")
-    exec(open(VERSION_PY_PATH).read())
+exec(open(VERSION_PY_PATH).read())
 
 
 class FormatCommand(Command):

--- a/setup.py
+++ b/setup.py
@@ -17,23 +17,27 @@ from os import path, makedirs, system
 import subprocess
 import sys
 
-try:
-    gitversion = (
-        subprocess.check_output(
-            "git describe --tags --always --first-parent".split()
+VERSION_PY_PATH = "conjure_python_client/_version.py"
+
+
+if not path.exists(VERSION_PY_PATH):
+    try:
+        gitversion = (
+            subprocess.check_output(
+                "git describe --tags --always --first-parent".split()
+            )
+            .decode()
+            .strip()
+            .replace("-", "_")
         )
-        .decode()
-        .strip()
-        .replace("-", "_")
-    )
-    open("conjure_python_client/_version.py", "w").write(
-        '__version__ = "{}"\n'.format(gitversion)
-    )
-    if not path.exists("build"):
-        makedirs("build")
-except subprocess.CalledProcessError:
-    print("outside git repo, not generating new version string")
-exec(open("conjure_python_client/_version.py").read())
+        open(VERSION_PY_PATH, "w").write(
+            '__version__ = "{}"\n'.format(gitversion)
+        )
+        if not path.exists("build"):
+            makedirs("build")
+    except subprocess.CalledProcessError:
+        print("outside git repo, not generating new version string")
+    exec(open(VERSION_PY_PATH).read())
 
 
 class FormatCommand(Command):


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Porting https://github.com/palantir/conjure-python-client/pull/139 to `develop`

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
 Do not overwrite the _version.py file if it already exists
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

