### PR TITLE
Pass in type_of_union for decoding union type

### DIFF
--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -105,7 +105,7 @@ class ConjureDecoder(object):
             value = obj[type_of_union]
             field_type = conjure_field_definition.field_type
             deserialized[attribute] = cls.do_decode(value, field_type)
-        return conjure_type(**deserialized)
+        return conjure_type(**deserialized, type_of_union=type_of_union)
 
     @classmethod
     def decode_conjure_enum_type(cls, obj, conjure_type):

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -108,7 +108,8 @@ class ConjureDecoder(object):
 
         # for backwards compatibility with conjure-python,
         # only pass in type_of_union if it is expected
-        if 'type_of_union' in conjure_type.__code__.co_varnames:
+        param_dict = inspect.signature(conjure_type.__init__).parameters
+        if 'type_of_union' in param_dict:
             deserialized['type_of_union'] = type_of_union
         return conjure_type(**deserialized)
 

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -105,7 +105,12 @@ class ConjureDecoder(object):
             value = obj[type_of_union]
             field_type = conjure_field_definition.field_type
             deserialized[attribute] = cls.do_decode(value, field_type)
-        return conjure_type(**deserialized, type_of_union=type_of_union)
+
+        # for backwards compatibility with conjure-python,
+        # only pass in type_of_union if it is expected
+        if 'type_of_union' in conjure_type.__code__.co_varnames:
+            deserialized['type_of_union'] = type_of_union
+        return conjure_type(**deserialized)
 
     @classmethod
     def decode_conjure_enum_type(cls, obj, conjure_type):


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Pass in type_of_union to the constructor when decoding a union type 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Should be merged with https://github.com/palantir/conjure-python/pull/681

