### PR TITLE
Pass in type_of_union for decoding union type

### DIFF
--- a/changelog/@unreleased/pr-142.v2.yml
+++ b/changelog/@unreleased/pr-142.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Pass in type_of_union to the constructor when decoding a union type. Relevant PR to conjure-python: palantir/conjure-python#681
+  links:
+  - https://github.com/palantir/conjure-python-client/pull/142

--- a/changelog/@unreleased/pr-142.v2.yml
+++ b/changelog/@unreleased/pr-142.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: Pass in type_of_union to the constructor when decoding a union type. Relevant PR to conjure-python: palantir/conjure-python#681
+  description: Pass in type_of_union to the constructor when decoding a union type. Relevant PR to conjure-python: https://github.com/palantir/conjure-python/pull/681
   links:
   - https://github.com/palantir/conjure-python-client/pull/142

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -124,7 +124,7 @@ class ConjureDecoder(object):
             deserialized[attribute] = cls.do_decode(value, field_type)
 
         # for backwards compatibility with conjure-python,
-        # only pass in type_of_union if it is expected
+        # only pass in argument type_of_union if it is expected
         if 'type_of_union' in conjure_type.__code__.co_varnames:
             deserialized['type_of_union'] = type_of_union
         return conjure_type(**deserialized)

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -123,7 +123,7 @@ class ConjureDecoder(object):
             field_type = conjure_field_definition.field_type
             deserialized[attribute] = cls.do_decode(value, field_type)
 
-        # for backwards compatibility with conjure-python, 
+        # for backwards compatibility with conjure-python,
         # only pass in type_of_union if it is expected
         if 'type_of_union' in conjure_type.__code__.co_varnames:
             deserialized['type_of_union'] = type_of_union

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -122,7 +122,7 @@ class ConjureDecoder(object):
             value = obj[type_of_union]
             field_type = conjure_field_definition.field_type
             deserialized[attribute] = cls.do_decode(value, field_type)
-        return conjure_type(**deserialized)
+        return conjure_type(**deserialized, type_of_union=type_of_union)
 
     @classmethod
     def decode_conjure_enum_type(cls, obj, conjure_type):

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -124,7 +124,7 @@ class ConjureDecoder(object):
             deserialized[attribute] = cls.do_decode(value, field_type)
 
         # for backwards compatibility with conjure-python,
-        # only pass in argument type_of_union if it is expected
+        # only pass in arg type_of_union if it is expected
         if 'type_of_union' in conjure_type.__code__.co_varnames:
             deserialized['type_of_union'] = type_of_union
         return conjure_type(**deserialized)

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -122,7 +122,12 @@ class ConjureDecoder(object):
             value = obj[type_of_union]
             field_type = conjure_field_definition.field_type
             deserialized[attribute] = cls.do_decode(value, field_type)
-        return conjure_type(**deserialized, type_of_union=type_of_union)
+
+        # for backwards compatibility with conjure-python,
+        # only pass in type_of_union if it is expected
+        if 'type_of_union' in conjure_type.__code__.co_varnames:
+            deserialized['type_of_union'] = type_of_union
+        return conjure_type(**deserialized)
 
     @classmethod
     def decode_conjure_enum_type(cls, obj, conjure_type):

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -123,7 +123,7 @@ class ConjureDecoder(object):
             field_type = conjure_field_definition.field_type
             deserialized[attribute] = cls.do_decode(value, field_type)
 
-        # for backwards compatibility with conjure-python,
+        # for backwards compatibility with conjure-python, 
         # only pass in type_of_union if it is expected
         if 'type_of_union' in conjure_type.__code__.co_varnames:
             deserialized['type_of_union'] = type_of_union


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Pass in type_of_union to the constructor when decoding a union type. Relevant PR to conjure-python: https://github.com/palantir/conjure-python/pull/681
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

