### PR TITLE
Use correct constructor signature of conjure type

### DIFF
--- a/changelog/@unreleased/pr-143.v2.yml
+++ b/changelog/@unreleased/pr-143.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Use correct constructor signature of conjure type to determine if type_of_union is a parameter
+  links:
+  - https://github.com/palantir/conjure-python-client/pull/143

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -125,7 +125,8 @@ class ConjureDecoder(object):
 
         # for backwards compatibility with conjure-python,
         # only pass in arg type_of_union if it is expected
-        if 'type_of_union' in inspect.signature(conjure_type.__init__).parameters:
+        param_dict = inspect.signature(conjure_type.__init__).parameters
+        if 'type_of_union' in param_dict:
             deserialized['type_of_union'] = type_of_union
         return conjure_type(**deserialized)
 

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -125,7 +125,7 @@ class ConjureDecoder(object):
 
         # for backwards compatibility with conjure-python,
         # only pass in arg type_of_union if it is expected
-        if 'type_of_union' in conjure_type.__code__.co_varnames:
+        if 'type_of_union' in inspect.signature(conjure_type.__init__).parameters:
             deserialized['type_of_union'] = type_of_union
         return conjure_type(**deserialized)
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Use correct constructor signature of conjure type to determine if type_of_union is a parameter
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

