### PR TITLE
Retry on connection errors

### DIFF
--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -168,7 +168,8 @@ class RequestsClient(object):
         # setup retry to match java remoting
         # https://github.com/palantir/http-remoting/tree/3.12.0#quality-of-service-retry-failover-throttling
         retry = RetryWithJitter(
-            total=service_config.max_num_retries,
+            total=service_config.max_num_retries, # this takes precedence over all other configs
+            connect=service_config.max_num_retries, # retry on connection resets, etc.
             read=0,  # do not retry read errors
             status_forcelist=[308, 429, 503],
             backoff_factor=float(service_config.backoff_slot_size) / 1000,


### PR DESCRIPTION
## Before this PR
Conjure-python-client does not retry on connection errors. If a connection is reset by the server, the client gives up instead of trying a different host.

## After this PR
==COMMIT_MSG==
Retry on connection errors
==COMMIT_MSG==
