### PR TITLE
Add flag to enable TCP keepalives

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Local development
 
-A light-weight HTTP client library.
+A light-weight HTTP client library for conjure.
 
 ### Overview
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # conjure-python-client
 
+Test
+
 ## Local development
 
 A light-weight HTTP client library.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 # conjure-python-client
 
-Test
-
 ## Local development
 
 A light-weight HTTP client library.

--- a/changelog/@unreleased/pr-161.v2.yml
+++ b/changelog/@unreleased/pr-161.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add flag to enable TCP keepalives
+  links:
+  - https://github.com/palantir/conjure-python-client/pull/161

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -176,7 +176,9 @@ class RequestsClient(object):
             status_forcelist=[308, 429, 503],
             backoff_factor=float(service_config.backoff_slot_size) / 1000,
         )
-        transport_adapter = TransportAdapter(max_retries=retry, enable_keep_alive=enable_keep_alive)
+        transport_adapter = TransportAdapter(
+            max_retries=retry, enable_keep_alive=enable_keep_alive
+        )
         # create a session, for shared connection polling, user agent, etc
         session = requests.Session()
         session.headers = CaseInsensitiveDict({"User-Agent": user_agent})
@@ -198,10 +200,10 @@ class RequestsClient(object):
 
 class TransportAdapter(HTTPAdapter):
     """Transport adapter that allows customising ssl things"""
+
     def __init__(self, *args, enable_keep_alive: bool = False, **kwargs):
         self._enable_keep_alive = enable_keep_alive
         super().__init__(*args, **kwargs)
-
 
     def init_poolmanager(
         self, connections, maxsize, block=False, **pool_kwargs
@@ -211,12 +213,24 @@ class TransportAdapter(HTTPAdapter):
         self._pool_block = block
         ssl_context = create_urllib3_context(ciphers=CIPHERS)
         keep_alive_pool_kwargs = {
-            'socket_options':
-                HTTPConnection.default_socket_options + [
-                    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),  # Enable keep alive.
-                    (socket.SOL_TCP, socket.TCP_KEEPIDLE, 120),  # After 120s of idle connection, start keepalive probes.
-                    (socket.SOL_TCP, socket.TCP_KEEPINTVL, 120)  # Interval of 120s between individual keepalive probes.
-                ]
+            "socket_options": HTTPConnection.default_socket_options
+            + [
+                (
+                    socket.SOL_SOCKET,
+                    socket.SO_KEEPALIVE,
+                    1,
+                ),  # Enable keep alive.
+                (
+                    socket.SOL_TCP,
+                    socket.TCP_KEEPIDLE,
+                    120,
+                ),  # After 120s of idle connection, start keepalive probes.
+                (
+                    socket.SOL_TCP,
+                    socket.TCP_KEEPINTVL,
+                    120,
+                ),  # Interval of 120s between individual keepalive probes.
+            ]
         }
         if self._enable_keep_alive:
             pool_kwargs = {**pool_kwargs, **keep_alive_pool_kwargs}
@@ -224,7 +238,6 @@ class TransportAdapter(HTTPAdapter):
             num_pools=connections,
             maxsize=maxsize,
             block=block,
-            strict=True,
             ssl_context=ssl_context,
             **pool_kwargs
         )

--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -141,8 +141,8 @@ class ConjureDecoder(object):
         # for backwards compatibility with conjure-python,
         # only pass in arg type_of_union if it is expected
         param_dict = inspect.signature(conjure_type.__init__).parameters
-        if 'type_of_union' in param_dict:
-            deserialized['type_of_union'] = type_of_union
+        if "type_of_union" in param_dict:
+            deserialized["type_of_union"] = type_of_union
         return conjure_type(**deserialized)
 
     @classmethod

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,9 @@ def convert_sls_version_to_python(sls_version: str) -> str:
         python_version += "rc" + rc_group
     if distance_group:
         if not hash_group:
-            raise RuntimeError(f"Cannot specify commit distance without hash for version {sls_version}")
+            raise RuntimeError(
+                f"Cannot specify commit distance without hash for version {sls_version}"
+            )
         python_version += "+" + distance_group + ".g" + hash_group
     if dirty_group:
         python_version += "." + dirty_group
@@ -61,7 +63,9 @@ try:
         .strip()
     )
     open(VERSION_PY_PATH, "w").write(
-        '__version__ = "{}"\n'.format(convert_sls_version_to_python(gitversion))
+        '__version__ = "{}"\n'.format(
+            convert_sls_version_to_python(gitversion)
+        )
     )
     if not path.exists("build"):
         makedirs("build")
@@ -113,12 +117,12 @@ setup(
     # The project's main homepage.
     url="https://github.com/palantir/conjure-python-client",
     author="Palantir Technologies, Inc.",
-    classifiers=[ 
+    classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10"
+        "Programming Language :: Python :: 3.10",
     ],
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().

--- a/test/http/test_requests_client.py
+++ b/test/http/test_requests_client.py
@@ -1,0 +1,40 @@
+import sys
+
+from conjure_python_client._http.requests_client import (
+    SOCKET_KEEP_ALIVE,
+    SOCKET_KEEP_INTVL,
+    TransportAdapter,
+)
+
+if sys.platform != "darwin":
+    from conjure_python_client._http.requests_client import SOCKET_KEEP_IDLE
+
+
+def test_can_enable_keep_alives_in_transport_adapter():
+    assert (
+        TransportAdapter(
+            max_retries=12, enable_keep_alive=True
+        )._enable_keep_alive
+        is True
+    )
+    assert TransportAdapter(max_retries=12)._enable_keep_alive is False
+    assert TransportAdapter()._enable_keep_alive is False
+
+
+def test_keep_alive_passes_correct_options():
+    socket_options = TransportAdapter(
+        max_retries=12, enable_keep_alive=True
+    ).poolmanager.connection_pool_kw["socket_options"]
+    assert SOCKET_KEEP_ALIVE in socket_options
+    assert SOCKET_KEEP_INTVL in socket_options
+    if sys.platform != "darwin":
+        assert SOCKET_KEEP_IDLE in socket_options
+
+
+def test_keep_alive_passed_in_state_in_transport_adapter():
+    ta = TransportAdapter()
+    ta.__setstate__(
+        TransportAdapter(max_retries=12, enable_keep_alive=True).__getstate__()
+    )
+    assert ta._enable_keep_alive is True
+    assert ta.max_retries.total == 12

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands =
     pytest -v --capture=no --junitxml=./build/pytest-{envname}.xml --html=./build/pytest-{envname}.html --self-contained-html {posargs:test/}
 deps =
     pytest==7.0.1
-    pytest-pylint==0.18.0
+    pytest-pylint==0.21.0
     pytest-html==3.1.1
     pyyaml==5.3.1
 setenv =


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
Add `enable_keep_alive` flag to requests client to enable tcp keep alives to be sent for open connections. This addresses some issues we've seen in certain environments where connection reset errors like `ConnectionResetError(104, 'Connection reset by peer'))` which after investigation seems to be remediate in some cases by enabling keep alives. This has seemed to alleviate the issue we've seen so rolling out as an opt-in feature.
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

