### PR TITLE
Fix version issue and make TransportAdapter state backwards compatible

### DIFF
--- a/changelog/@unreleased/pr-164.v2.yml
+++ b/changelog/@unreleased/pr-164.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix version issues with conda feedstock
+  links:
+  - https://github.com/palantir/conjure-python-client/pull/164

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -251,7 +251,7 @@ class TransportAdapter(HTTPAdapter):
     def __setstate__(self, state):
         if self.ENABLE_KEEP_ALIVE_ATTR not in state:
             state[self.ENABLE_KEEP_ALIVE_ATTR] = False
-        super().__setstate__(state)
+        super().__setstate__(state)  # type: ignore
 
 
 class ConjureHTTPError(HTTPError):

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -219,8 +219,9 @@ class RequestsClient(object):
 
 class TransportAdapter(HTTPAdapter):
     """Transport adapter that allows customising ssl things"""
+    ENABLE_KEEP_ALIVE_ATTR = "_enable_keep_alive"
 
-    __attrs__ = HTTPAdapter.__attrs__ + ["_enable_keep_alive"]
+    __attrs__ = HTTPAdapter.__attrs__ + [ENABLE_KEEP_ALIVE_ATTR]
 
     def __init__(self, *args, enable_keep_alive: bool = False, **kwargs):
         self._enable_keep_alive = enable_keep_alive
@@ -246,6 +247,11 @@ class TransportAdapter(HTTPAdapter):
             ssl_context=ssl_context,
             **pool_kwargs
         )
+
+    def __setstate__(self, state):
+        if self.ENABLE_KEEP_ALIVE_ATTR not in state:
+            state[self.ENABLE_KEEP_ALIVE_ATTR] = False
+        super().__setstate__(state)
 
 
 class ConjureHTTPError(HTTPError):

--- a/setup.py
+++ b/setup.py
@@ -54,23 +54,24 @@ def convert_sls_version_to_python(sls_version: str) -> str:
     return python_version
 
 
-try:
-    gitversion = (
-        subprocess.check_output(
-            "git describe --tags --always --first-parent".split()
+if not path.exists(VERSION_PY_PATH):
+    try:
+        gitversion = (
+            subprocess.check_output(
+                "git describe --tags --always --first-parent".split()
+            )
+            .decode()
+            .strip()
         )
-        .decode()
-        .strip()
-    )
-    open(VERSION_PY_PATH, "w").write(
-        '__version__ = "{}"\n'.format(
-            convert_sls_version_to_python(gitversion)
+        open(VERSION_PY_PATH, "w").write(
+            '__version__ = "{}"\n'.format(
+                convert_sls_version_to_python(gitversion)
+            )
         )
-    )
-    if not path.exists("build"):
-        makedirs("build")
-except subprocess.CalledProcessError:
-    print("outside git repo, not generating new version string")
+        if not path.exists("build"):
+            makedirs("build")
+    except subprocess.CalledProcessError:
+        print("outside git repo, not generating new version string")
 exec(open(VERSION_PY_PATH).read())
 
 

--- a/test/_http/test_requests_client.py
+++ b/test/_http/test_requests_client.py
@@ -1,3 +1,4 @@
+import pickle
 import sys
 
 from conjure_python_client._http.requests_client import (
@@ -12,9 +13,7 @@ if sys.platform != "darwin":
 
 def test_can_enable_keep_alives_in_transport_adapter():
     assert (
-        TransportAdapter(
-            max_retries=12, enable_keep_alive=True
-        )._enable_keep_alive
+        TransportAdapter(max_retries=12, enable_keep_alive=True)._enable_keep_alive
         is True
     )
     assert TransportAdapter(max_retries=12)._enable_keep_alive is False
@@ -38,3 +37,24 @@ def test_keep_alive_passed_in_state_in_transport_adapter():
     )
     assert ta._enable_keep_alive is True
     assert ta.max_retries.total == 12
+
+
+def test_transport_adapter_pickles_correctly():
+    pre_adapter = TransportAdapter(enable_keep_alive=True)
+    post_adapter = pickle.loads(pickle.dumps(pre_adapter))
+    assert post_adapter._enable_keep_alive is True
+    assert post_adapter._pool_connections == pre_adapter._pool_connections
+    assert post_adapter._pool_maxsize == pre_adapter._pool_maxsize
+
+
+def test_transport_adapter_can_be_unpickled_from_old_pickle():
+    # Remove "_enable_keep_alive" attr from get state so that when picked it emulates an old instance of this
+    # class being pickled before this attr was added. Then verify we can pickle and unpickle to validate we
+    # give it a default value if not present when unpickled.
+    TransportAdapter.__getstate__ = lambda self: {
+        attr: getattr(self, attr, None)
+        for attr in self.__attrs__
+        if attr != TransportAdapter.ENABLE_KEEP_ALIVE_ATTR
+    }
+    adapter = pickle.loads(pickle.dumps(TransportAdapter()))
+    assert adapter._enable_keep_alive is False


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
conda feedstock tries to run git to get the version during conda build because I removed the logic that checks if _version.py already exists, which is does in that case, and we don't want this logic run at that point.

Also, some users of this lib have stored pickles of the old version of `TransportAdapter` and then when unpickling against this new version the `_enable_keep_alive` field is missing so changing state such that we can handle said case even though it's an odd workflow.
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

