### PR TITLE
fix: shallow copy issue of ConjureHTTPError

### DIFF
--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -294,16 +294,16 @@ class ConjureHTTPError(HTTPError):
         )
 
     def __copy__(self):
-        """The fact that ConjureHTTPError is a BaseException but its __init__ 
-        has a different signature causes a subtle issue for shallow copying. 
+        """The fact that ConjureHTTPError is a BaseException but its __init__
+        has a different signature causes a subtle issue for shallow copying.
         During copy.copy(), __init__ will be called with args defined by
-        BaseException.__reduce_, which corresponds to default __init__. Since 
-        they're inconsistent, what http_error receives is actually message, 
+        BaseException.__reduce_, which corresponds to default __init__. Since
+        they're inconsistent, what http_error receives is actually message,
         hence an error.
 
-        By defining a __copy__ method, we give instructions to the intepreter 
-        on how to reconstruct a ConjureHTTPError instance. Alternatively, we 
-        could also fix it by changing the _init__ signature of this class. 
+        By defining a __copy__ method, we give instructions to the intepreter
+        on how to reconstruct a ConjureHTTPError instance. Alternatively, we
+        could also fix it by changing the _init__ signature of this class.
         Although cleaner, unfortunately it will be a breaking change.
         """
 

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -293,6 +293,31 @@ class ConjureHTTPError(HTTPError):
             message, request=http_error.request, response=http_error.response
         )
 
+    def __copy__(self):
+        """The fact that ConjureHTTPError is a BaseException but its __init__ 
+        has a different signature causes a subtle issue for shallow copying. 
+        During copy.copy(), __init__ will be called with args defined by
+        BaseException.__reduce_, which corresponds to default __init__. Since 
+        they're inconsistent, what http_error receives is actually message, 
+        hence an error.
+
+        By defining a __copy__ method, we give instructions to the intepreter 
+        on how to reconstruct a ConjureHTTPError instance. Alternatively, we 
+        could also fix it by changing the _init__ signature of this class. 
+        Although cleaner, unfortunately it will be a breaking change.
+        """
+
+        # Create a shell object without calling __init__
+        new_obj = type(self).__new__(type(self))
+
+        for attr, value in self.__dict__.items():
+            setattr(new_obj, attr, value)
+
+        # Exception args are not actually a part of __dict__...
+        new_obj.args = self.args
+
+        return new_obj
+
     @property
     def cause(self) -> Optional[HTTPError]:
         """The wrapped ``HTTPError`` that was the direct cause of

--- a/test/_http/test_requests_client.py
+++ b/test/_http/test_requests_client.py
@@ -1,7 +1,11 @@
+import copy
 import pickle
 import sys
 
+from requests.exceptions import HTTPError
+
 from conjure_python_client._http.requests_client import (
+    ConjureHTTPError,
     SOCKET_KEEP_ALIVE,
     SOCKET_KEEP_INTVL,
     TransportAdapter,
@@ -58,3 +62,18 @@ def test_transport_adapter_can_be_unpickled_from_old_pickle():
     }
     adapter = pickle.loads(pickle.dumps(TransportAdapter()))
     assert adapter._enable_keep_alive is False
+
+def test_shallow_copying_conjure_http_error():
+    class MockResponse:
+        def __init__(self):
+            self.headers = {"X-B3-TraceId": "test"}
+
+        def json(self):
+            return {}
+
+    response = MockResponse()
+    http_error = HTTPError("HTTP 500 Server Error", response=response)
+    original_error = ConjureHTTPError(http_error)
+
+    copied_error = copy.copy(original_error)
+    assert str(original_error) == str(copied_error)

--- a/test/_http/test_requests_client.py
+++ b/test/_http/test_requests_client.py
@@ -2,14 +2,13 @@ import copy
 import pickle
 import sys
 
-from requests.exceptions import HTTPError
-
 from conjure_python_client._http.requests_client import (
     ConjureHTTPError,
     SOCKET_KEEP_ALIVE,
     SOCKET_KEEP_INTVL,
     TransportAdapter,
 )
+from requests.exceptions import HTTPError
 
 if sys.platform != "darwin":
     from conjure_python_client._http.requests_client import SOCKET_KEEP_IDLE
@@ -76,4 +75,5 @@ def test_shallow_copying_conjure_http_error():
     original_error = ConjureHTTPError(http_error)
 
     copied_error = copy.copy(original_error)
+    assert type(original_error) is type(copied_error)
     assert str(original_error) == str(copied_error)


### PR DESCRIPTION
## Before this PR

When a `ConjureHTTPError` gets shallow copied, an exception will be thrown as follow:

```
 def __init__(self, http_error: HTTPError) -> None:
        self._cause = http_error
>       self._trace_id = http_error.response.headers.get("X-B3-TraceId")
E       AttributeError: 'str' object has no attribute 'response'
```

The added unit test is a minimal repro. I added details in the comment, but basically there's a mismatch between `ConjureHTTPError.__init__` and `BaseException.__init__`. This is breaking because when [doing shallow copying](https://github.com/python/cpython/blob/main/Lib/copy.py#L62), an exception instance is constructed [via `__reduce__`](https://github.com/python/cpython/blob/main/Objects/exceptions.c#L222), which calls `__init__` with exception `args` where the first element is a `message`. Therefore when `ConjureHTTPError` gets constructed via `copy.copy()`, the `http_error` it receives from `__init__` is actually `message`, which is `str` hence the exception.

This PR fixes it by implementing `__copy__` to instruct how to soft copy. Alternatively we could fix the init signature, however that will be a breaking change.

## After this PR

Unit test passes.

==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

