### PR TITLE
Improvement: Do not dump raw object during decoding

### DIFF
--- a/conjure_python_client/_serde/decoder.py
+++ b/conjure_python_client/_serde/decoder.py
@@ -89,8 +89,8 @@ class ConjureDecoder(object):
             deserialized[python_arg_name] = {}
         else:
             raise Exception(
-                "field {} not found in object {}".format(
-                    field_definition.identifier, obj
+                "field {} not found in the object".format(
+                    field_definition.identifier
                 )
             )
 

--- a/test/serde/test_decode_object.py
+++ b/test/serde/test_decode_object.py
@@ -59,7 +59,7 @@ def test_object_with_missing_field_should_throw_helpful_exception():
         ConjureDecoder().read_from_string(
             """{"path": "bar", "redundant": 1}""", CreateDatasetRequest
         )
-    message_regex = re.compile("field fileSystemId not found in object {.+}")
+    message_regex = re.compile("field fileSystemId not found in the object")
     assert message_regex.match(str(excinfo.value)), excinfo.value
 
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Raw object are getting dumped during decoding, potentially leaking sensitive data.

## After this PR

Don't do this.

Also spotchecked the repo to make sure there's no other leakages. We do print raw objects in `__repr__` but that's by design and that's more on consumers/devs for not using it in the production envs.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Do not dump raw object during decoding
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

