### PR TITLE
Improvement: Add Conjure `ErrorCode` enum type

### DIFF
--- a/conjure_python_client/__init__.py
+++ b/conjure_python_client/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
     "ConjureUnionType",
     "DecodableType",
     "DictType",
+    "ErrorCode",
     "ListType",
     "OptionalType",
     "OptionalTypeWrapper",

--- a/conjure_python_client/_http/__init__.py
+++ b/conjure_python_client/_http/__init__.py
@@ -14,6 +14,7 @@
 
 from .configuration import SslConfiguration, ServiceConfiguration
 from .requests_client import RequestsClient, Service, ConjureHTTPError
+from .errors import ErrorCode
 
 __all__ = [
     "SslConfiguration",
@@ -21,4 +22,5 @@ __all__ = [
     "RequestsClient",
     "Service",
     "ConjureHTTPError",
+    "ErrorCode",
 ]

--- a/conjure_python_client/_http/__init__.py
+++ b/conjure_python_client/_http/__init__.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 from .configuration import SslConfiguration, ServiceConfiguration
-from .requests_client import RequestsClient, Service, ConjureHTTPError
 from .errors import ErrorCode
+from .requests_client import RequestsClient, Service, ConjureHTTPError
 
 __all__ = [
     "SslConfiguration",

--- a/conjure_python_client/_http/errors.py
+++ b/conjure_python_client/_http/errors.py
@@ -1,0 +1,34 @@
+# (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+
+
+class ErrorCode(str, Enum):
+    """Conjure error codes as defined in the Conjure specification."""
+
+    PERMISSION_DENIED = "PERMISSION_DENIED"
+    INVALID_ARGUMENT = "INVALID_ARGUMENT"
+    NOT_FOUND = "NOT_FOUND"
+    CONFLICT = "CONFLICT"
+    REQUEST_ENTITY_TOO_LARGE = "REQUEST_ENTITY_TOO_LARGE"
+    FAILED_PRECONDITION = "FAILED_PRECONDITION"
+    INTERNAL = "INTERNAL"
+    TIMEOUT = "TIMEOUT"
+    CUSTOM_CLIENT = "CUSTOM_CLIENT"
+    CUSTOM_SERVER = "CUSTOM_SERVER"
+
+    def __str__(self) -> str:
+        """Return just the string value"""
+        return self.value

--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -20,6 +20,7 @@ from requests.packages.urllib3.poolmanager import PoolManager
 from requests.packages.urllib3.util.ssl_ import create_urllib3_context
 from requests.packages.urllib3.util import Retry
 from .configuration import ServiceConfiguration
+from .errors import ErrorCode
 
 import binascii
 import os
@@ -260,7 +261,7 @@ class ConjureHTTPError(HTTPError):
     attributes extracted from the response."""
 
     _cause: Optional[HTTPError]
-    _error_code: str
+    _error_code: ErrorCode
     _error_name: str
     _error_instance_id: str
     _parameters: Dict[str, str]

--- a/test/_http/test_errors.py
+++ b/test/_http/test_errors.py
@@ -1,0 +1,46 @@
+# (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from conjure_python_client import ErrorCode
+
+
+class TestErrorCode:
+    def test_string_convertion(self):
+        assert str(ErrorCode.NOT_FOUND) == "NOT_FOUND"
+        assert str(ErrorCode.INVALID_ARGUMENT) == "INVALID_ARGUMENT"
+
+    def test_error_code_string_equality(self):
+        assert ErrorCode.NOT_FOUND == "NOT_FOUND"
+        assert ErrorCode.INVALID_ARGUMENT == "INVALID_ARGUMENT"
+        assert ErrorCode.NOT_FOUND != "INVALID_ARGUMENT"
+
+    def test_error_code_creation_from_string(self):
+        assert ErrorCode("NOT_FOUND") == ErrorCode.NOT_FOUND
+        assert ErrorCode("INVALID_ARGUMENT") == ErrorCode.INVALID_ARGUMENT
+
+    def test_all_error_codes_exist(self):
+        expected_codes = {
+            "PERMISSION_DENIED",
+            "INVALID_ARGUMENT",
+            "NOT_FOUND",
+            "CONFLICT",
+            "REQUEST_ENTITY_TOO_LARGE",
+            "FAILED_PRECONDITION",
+            "INTERNAL",
+            "TIMEOUT",
+            "CUSTOM_CLIENT",
+            "CUSTOM_SERVER",
+        }
+        actual_codes = {code.value for code in ErrorCode}
+        assert actual_codes == expected_codes

--- a/test/_http/test_errors.py
+++ b/test/_http/test_errors.py
@@ -28,19 +28,3 @@ class TestErrorCode:
     def test_error_code_creation_from_string(self):
         assert ErrorCode("NOT_FOUND") == ErrorCode.NOT_FOUND
         assert ErrorCode("INVALID_ARGUMENT") == ErrorCode.INVALID_ARGUMENT
-
-    def test_all_error_codes_exist(self):
-        expected_codes = {
-            "PERMISSION_DENIED",
-            "INVALID_ARGUMENT",
-            "NOT_FOUND",
-            "CONFLICT",
-            "REQUEST_ENTITY_TOO_LARGE",
-            "FAILED_PRECONDITION",
-            "INTERNAL",
-            "TIMEOUT",
-            "CUSTOM_CLIENT",
-            "CUSTOM_SERVER",
-        }
-        actual_codes = {code.value for code in ErrorCode}
-        assert actual_codes == expected_codes


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

The `ErrorCode` isn't captured as part of the library. It would've been handy for my work resolving https://github.com/palantir/conjure-python/issues/910 where the `ErrorCode` will be imported and used as part of the generated Conjure Error.

## After this PR

Adding the enum type and make `ConjureHTTPError` use that. Since it's a stringish enum, it should be generally free from back compat issues.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add Conjure `ErrorCode` enum type
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
