### PR TITLE
Allow running conjure-python-client on Windows

### DIFF
--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -26,7 +26,6 @@ import os
 import random
 import requests
 import socket
-import sys
 
 
 T = TypeVar("T")
@@ -55,13 +54,15 @@ SOCKET_KEEP_ALIVE = (
     socket.SO_KEEPALIVE,
     1,
 )  # Enable keep alive.
-SOCKET_KEEP_INTVL = (
-    socket.SOL_TCP,
-    socket.TCP_KEEPINTVL,
-    120,
-)  # Interval of 120s between individual keepalive probes.
-KEEP_ALIVE_SOCKET_OPTIONS = [SOCKET_KEEP_ALIVE, SOCKET_KEEP_INTVL]
-if sys.platform != "darwin":
+KEEP_ALIVE_SOCKET_OPTIONS = [SOCKET_KEEP_ALIVE]
+if hasattr(socket, "TCP_KEEPINTVL"):
+    SOCKET_KEEP_INTVL = (
+        socket.SOL_TCP,
+        socket.TCP_KEEPINTVL,
+        120,
+    )  # Interval of 120s between individual keepalive probes.
+    KEEP_ALIVE_SOCKET_OPTIONS.append(SOCKET_KEEP_INTVL)
+if hasattr(socket, "TCP_KEEPIDLE"):
     SOCKET_KEEP_IDLE = (
         socket.SOL_TCP,
         socket.TCP_KEEPIDLE,

--- a/test/_http/test_requests_client.py
+++ b/test/_http/test_requests_client.py
@@ -1,16 +1,17 @@
 import copy
 import pickle
-import sys
+import socket
 
 from conjure_python_client._http.requests_client import (
     ConjureHTTPError,
     SOCKET_KEEP_ALIVE,
-    SOCKET_KEEP_INTVL,
     TransportAdapter,
 )
 from requests.exceptions import HTTPError
 
-if sys.platform != "darwin":
+if hasattr(socket, "TCP_KEEPINTVL"):
+    from conjure_python_client._http.requests_client import SOCKET_KEEP_INTVL
+if hasattr(socket, "TCP_KEEPIDLE"):
     from conjure_python_client._http.requests_client import SOCKET_KEEP_IDLE
 
 
@@ -28,8 +29,9 @@ def test_keep_alive_passes_correct_options():
         max_retries=12, enable_keep_alive=True
     ).poolmanager.connection_pool_kw["socket_options"]
     assert SOCKET_KEEP_ALIVE in socket_options
-    assert SOCKET_KEEP_INTVL in socket_options
-    if sys.platform != "darwin":
+    if hasattr(socket, "TCP_KEEPINTVL"):
+        assert SOCKET_KEEP_INTVL in socket_options
+    if hasattr(socket, "TCP_KEEPIDLE"):
         assert SOCKET_KEEP_IDLE in socket_options
 
 


### PR DESCRIPTION
## Before this PR
TCP_KEEPINTVL and TCP_KEEPIDLE are not available in every Python build on Windows. Previously, TCP_KEEPINTVL was used unconditionally (crashing on Windows) and TCP_KEEPIDLE was only gated for macOS (also crashing on Windows.


See https://github.com/python/cpython/blob/b32c830d444c85421bd2c0c7af494c9d85485a29/Modules/socketmodule.c#L337-L340 which shows it's available from api version 16299. 

Notably, the conda-forge builds of Python use a lower api version, I think it's because of their old Windows image (https://github.com/conda-forge/python-feedstock/blob/02184ce041a6bfa67e45fb2472a587ef13a99669/.azure-pipelines/azure-pipelines-win.yml#L8) but I'm not entirely sure.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow running conjure-python-client on Windows
==COMMIT_MSG==

Only try accessing the properties if they're available.