### PR TITLE
Fix ConjureHTTPError pickling crash in multiprocessing

### DIFF
--- a/conjure_python_client/_http/requests_client.py
+++ b/conjure_python_client/_http/requests_client.py
@@ -255,6 +255,14 @@ class TransportAdapter(HTTPAdapter):
         super().__setstate__(state)  # type: ignore
 
 
+def _reconstruct_conjure_http_error(cls, state):
+    obj = cls.__new__(cls)
+    args = state.pop("args", ())
+    obj.__dict__.update(state)
+    obj.args = args
+    return obj
+
+
 class ConjureHTTPError(HTTPError):
     """An HTTPError from a Conjure Service with ``SerializableError``
     attributes extracted from the response."""
@@ -295,29 +303,15 @@ class ConjureHTTPError(HTTPError):
         )
 
     def __copy__(self):
-        """The fact that ConjureHTTPError is a BaseException but its __init__
-        has a different signature causes a subtle issue for shallow copying.
-        During copy.copy(), __init__ will be called with args defined by
-        BaseException.__reduce_, which corresponds to default __init__. Since
-        they're inconsistent, what http_error receives is actually message,
-        hence an error.
-
-        By defining a __copy__ method, we give instructions to the intepreter
-        on how to reconstruct a ConjureHTTPError instance. Alternatively, we
-        could also fix it by changing the _init__ signature of this class.
-        Although cleaner, unfortunately it will be a breaking change.
-        """
-
-        # Create a shell object without calling __init__
         new_obj = type(self).__new__(type(self))
-
-        for attr, value in self.__dict__.items():
-            setattr(new_obj, attr, value)
-
-        # Exception args are not actually a part of __dict__...
+        new_obj.__dict__.update(self.__dict__)
         new_obj.args = self.args
-
         return new_obj
+
+    def __reduce__(self):
+        state = self.__dict__.copy()
+        state["args"] = self.args
+        return (_reconstruct_conjure_http_error, (type(self), state))
 
     @property
     def cause(self) -> Optional[HTTPError]:

--- a/test/_http/test_requests_client.py
+++ b/test/_http/test_requests_client.py
@@ -77,3 +77,23 @@ def test_shallow_copying_conjure_http_error():
     copied_error = copy.copy(original_error)
     assert type(original_error) is type(copied_error)
     assert str(original_error) == str(copied_error)
+
+
+def test_pickling_conjure_http_error():
+    from requests.models import Response, PreparedRequest
+
+    response = Response()
+    response.status_code = 500
+    response.headers["X-B3-TraceId"] = "test"
+    response._content = b'{"errorCode": "INTERNAL", "errorName": "Default:Internal", "errorInstanceId": "abc", "parameters": {}}'
+    request = PreparedRequest()
+    request.prepare_url("http://example.com", {})
+    request.prepare_method("GET")
+    response.request = request
+
+    http_error = HTTPError("HTTP 500 Server Error", response=response, request=request)
+    original_error = ConjureHTTPError(http_error)
+
+    unpickled_error = pickle.loads(pickle.dumps(original_error))
+    assert type(original_error) is type(unpickled_error)
+    assert str(original_error) == str(unpickled_error)


### PR DESCRIPTION
## Before this PR

PR #167 fixed a `copy.copy()` crash on `ConjureHTTPError` by adding a `__copy__` override, but the same underlying issue also affects pickling. `BaseException.__reduce__` produces pickle instructions that call `ConjureHTTPError.__init__(message_string)`, passing the string message as the `http_error` argument. Since `__init__` expects an `HTTPError` object with a `.response` attribute, this crashes with `AttributeError: 'str' object has no attribute 'response'`.

This surfaces when a `ConjureHTTPError` is raised inside a `ProcessPoolExecutor` worker — the pool tries to pickle the exception to send it back to the parent process, the unpickle fails, and the worker crashes with `BrokenProcessPool`.

## After this PR

`ConjureHTTPError` can be safely pickled and unpickled. This unblocks use of `ProcessPoolExecutor` (and any other pickle-based serialization) with code that may raise `ConjureHTTPError`.

==COMMIT_MSG==
Fix ConjureHTTPError pickling crash in multiprocessing

Override `__reduce__` to bypass `__init__` on reconstruction, matching the existing `__copy__` fix from #167.
==COMMIT_MSG==

## Possible downsides?

None. The current behavior (crashing on pickle) is a bug, not a contract. The public API, class hierarchy, and constructor signature are unchanged.
